### PR TITLE
Add automatic layout detection and title generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ For examples of building on this foundation, see the [demo site](https://christo
 ## Features
 
 - 🪶 Minimal, no-bloat foundation
+- 📝 Automatic front matter generation
+  - Page titles from first heading
+  - Layouts based on content location
 - 🔍 SEO-friendly metadata
 - 🗺️ Search engine sitemap
 - 📱 Mobile-first responsive design
@@ -33,9 +36,11 @@ If you prefer to start from scratch rather than using the template:
 
     # Required Plugins
     plugins:
-      - jekyll-remote-theme    # Required for remote themes
-      - jekyll-seo-tag        # Required for SEO meta tags
-      - jekyll-sitemap        # Required for search engines
+      - jekyll-remote-theme         # Required for remote themes
+      - jekyll-seo-tag             # Required for SEO meta tags
+      - jekyll-sitemap             # Required for search engines
+      - jekyll-titles-from-headings # Required for automatic page titles
+      - jekyll-default-layout      # Required for automatic layouts
 
     # Site Settings
     title: "Your Site Title"
@@ -61,21 +66,22 @@ If you prefer to start from scratch rather than using the template:
 2. Create your home page `index.md`:
     ```yaml
     ---
-    layout: default
-    title: Home
+    description: "Optional SEO description"  # Only if needed
     ---
 
-    Welcome to your new site!
+    # Welcome to Your Site
+
+    Your content starts here!
     ```
 
 3. Create a sample post in `_posts/YYYY-MM-DD-title.md` (optional - only if you want blog features):
     ```yaml
     ---
-    layout: post
-    title: "Your First Post"
-    date: YYYY-MM-DD
+    date: YYYY-MM-DD              # Required for posts
     description: "Optional SEO description"
     ---
+
+    # Your First Post
 
     Your post content here.
     ```
@@ -101,19 +107,38 @@ If you prefer to start from scratch rather than using the template:
     ```
    More details for running Jekyll locally are at the official [Jekyll Installation Guide](https://jekyllrb.com/docs/installation/).
 
-## Required Front Matter
+## Layouts
+
+BaseTheme uses automatic layout detection based on content location:
+
+1. Posts in `_posts/` → `post` layout
+2. Files named `index.md` → `home` layout
+3. Other `.md` files → `page` layout
+4. `.html` files → `default` layout
+
+You can override any automatic layout by specifying it in front matter:
 ```yaml
 ---
-layout: [default|post]
-title: "Page Title"
+layout: custom-layout
 ---
 ```
 
-## Optional Front Matter
+## Front Matter
+
+Required only for posts:
 ```yaml
 ---
-description: "SEO description"  # Recommended for SEO
-date: YYYY-MM-DD              # Required for posts only
+date: YYYY-MM-DD   # Date required for blog posts
+---
+```
+
+Optional front matter:
+```yaml
+---
+description: "SEO description"  # Optional: recommended for SEO
+permalink: /custom-url/         # Optional: custom URL path
+title: "Override Title"         # Optional: only if different from first heading
+layout: "custom"               # Optional: override automatic layout
 ---
 ```
 
@@ -123,4 +148,4 @@ This theme is released under [CC0](LICENSE) ("No Rights Reserved"). You can copy
 
 ## Author
 
-Created by Christopher Allen ([GitHub @ChristopherA](https://github.com/ChristopherA) | ChristopherA@LifeWithAlacrity.com)
+Created by Christopher Allen ([GitHub @ChristopherA](https://github.com/ChristopherA))

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,14 @@ plugins:
   - jekyll-remote-theme    # Required for using remote themes
   - jekyll-seo-tag         # Required for SEO meta tags
   - jekyll-sitemap         # Required for search engine sitemaps
+  - jekyll-titles-from-headings  # Required for automatic page titles
+  - jekyll-default-layout        # Required for automatic layouts
+
+# Plugin Configuration
+titles_from_headings:
+  strip_title: true      # Removes the first H1 from content
+  strip_spans: true      # Removes span tags from titles
+  collections: true      # Enables for collections
 
 # Default Site Settings
 # These serve as examples and can be overridden by sites using this theme

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,9 @@
+---
+layout: default
+---
+
+<div class="home">
+  <main id="main" class="page-content" aria-label="Content">
+    {{ content }}
+  </main>
+</div>


### PR DESCRIPTION
This PR adds automatic layout detection and title generation as core features of BaseTheme, reducing boilerplate in content files while maintaining flexibility.

### Changes

1. Added core plugins:
   - `jekyll-titles-from-headings` for automatic page title generation
   - `jekyll-default-layout` for automatic layout detection

2. Added plugin configuration:
   ```yaml
   titles_from_headings:
     strip_title: true      # Removes the first H1 from content
     strip_spans: true      # Removes span tags from titles
     collections: true      # Enables for collections
   ```

3. Added `_layouts/home.html` template for index pages
4. Updated README.md with new features and updated examples
5. Updated documentation of layout hierarchy and front matter requirements

### Automatic Layout Detection

Files will now automatically get the correct layout based on their location:
- `index.md` → `home` layout
- `_posts/*.md` → `post` layout
- Other `.md` files → `page` layout
- `.html` files → `default` layout

### Automatic Title Generation

Page titles are now automatically generated from the first H1 heading in the content, removing the need to specify titles in front matter.

### Breaking Changes

Users should update their `_config.yml` to include the new required plugins.